### PR TITLE
Limit back-off to a specified maximum; Improve usability of static .monitor() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ separate queue service such as RabbitMQ at an early stage.
 
 ## Rules
 - A task is an object that holds information that is meaningful to your app. The object's properties
-  must be storable in Firebase.
+  and values must be compatible with what Firebase supports, i.e., values must be primitives.
 - Tasks can be submitted for immediate execution or for execution at a specific time (i.e. delayed
   execution).
-- Tasks are not necessarily processed in the order they were submitted, but that is the general
+- Tasks are not guaranteed to be processed in the order they were submitted, but that is the general
   intention.
 - Tasks cannot have multiple user-defined statuses. They are either in the queue, i.e. not yet
   processed, or are not in the queue, i.e. processed successfully then deleted.
@@ -59,7 +59,7 @@ q.monitor(function(taskId, taskData, done) {
 
     // You can even do something asynchronous, as long as you remember to call done().
     setTimeout(function() {
-        done(true);
+        done();
     }, 500);
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -542,8 +542,12 @@ FireTaskQueue.unregisterQueue_ = function(queue) {
  * @param {string} queueName The name of the queue.
  * @param {ProcessorFn} fn A function that processes a task from the queue.
  * @param {number=} opt_parallelCount The number of tasks that are allowed to execute in parallel.
+ * @param {number=} opt_maxBackOff Failed tasks should be retried at intervals no larger than this
+ *  (microseconds).
+ * @param {number=} opt_minBackOff Failed tasks should be retried at intervals no smaller than this
+ *  (microseconds).
  */
-FireTaskQueue.monitor = function(queueName, fn, opt_parallelCount) {
+FireTaskQueue.monitor = function(queueName, fn, opt_parallelCount, opt_maxBackOff, opt_minBackOff) {
 
     var q = FireTaskQueue.get(queueName);
     if (q) {

--- a/src/index.js
+++ b/src/index.js
@@ -178,7 +178,10 @@ FireTaskQueue.prototype.schedule = function(taskData, opt_when) {
  * Registers a callback function that will be called for each task in the queue and starts
  * monitoring.
  *
- * @param {ProcessorFn} fn
+ * @param {ProcessorFn} fn A function that processes a task from the queue. It should accept the
+ *      following arguments: id {string}, task {!Object}, done {function(*)}
+ *      When processing is complete, done() should be called without arguments to indicate success,
+ *      and with an error or any other value except undefined and null to indicate failure.
  * @param {number=} opt_parallelCount The number of tasks that are allowed execute in parallel.
  * @param {number=} opt_maxBackOff Failed tasks should be retried at intervals no larger than this
  *  (microseconds).
@@ -540,7 +543,10 @@ FireTaskQueue.unregisterQueue_ = function(queue) {
  * Registers a function that will be called for each task in the queue, and starts processing tasks.
  *
  * @param {string} queueName The name of the queue.
- * @param {ProcessorFn} fn A function that processes a task from the queue.
+ * @param {ProcessorFn} fn A function that processes a task from the queue. It should accept the
+ *      following arguments: id {string}, task {!Object}, done {function(*)}
+ *      When processing is complete, done() should be called without arguments to indicate success,
+ *      and with an error or any other value except undefined and null to indicate failure.
  * @param {number=} opt_parallelCount The number of tasks that are allowed to execute in parallel.
  * @param {number=} opt_maxBackOff Failed tasks should be retried at intervals no larger than this
  *  (microseconds).
@@ -584,12 +590,12 @@ FireTaskQueue.log_ = function(var_args) {
 
 
 /**
- * Processor functions should accept a data argument and a second argument that is a function that
- * should be called when the processing is complete. If the function is called with true, the item
- * is considered to have been processed and will be deleted from the queue. If called with false,
- * It will remain in the queue, but get an updated due time.
+ * Processor functions should accept a task ID, a task data argument and a final argument that is a
+ * callback function for the consumer to call when the processing is complete. If any value apart
+ * from undefined or null is passed to the callback, the task is considered to have failed and
+ * will be retried after an appropriate interval.
  *
- * @typedef {function(string, !Object, function(boolean))}
+ * @typedef {function(string, !Object, function(*))}
  */
 var ProcessorFn;
 


### PR DESCRIPTION
- Support a maximum back-off interval, and make back-offs configurable via the `.monitor()` method.

``` javascript
/**
 * Registers a callback function that will be called for each task in the queue and starts
 * monitoring.
 *
 * ...
 * @param {number=} opt_maxBackOff Failed tasks should be retried at intervals no larger than this
 *  (microseconds).
 * @param {number=} opt_minBackOff Failed tasks should be retried at intervals no smaller than this
 *  (microseconds).
 */
FireTaskQueue.prototype.monitor = function(fn, opt_parallelCount, opt_maxBackOff, opt_minBackOff) { ... }
```
- Improve usability of the static `.monitor()` method: if passed a `Firebase.Ref`, it will auto-create a queue instance if necessary.

``` javascript
/**
 * Registers a function that will be called for each task in the queue, and starts processing tasks.
 *
 * @param {!Firebase|string} queueRefOrName The Firebase reference of the queue or its name. If passing a
 *      ref, the queue will be created if it does not yet exist. Passing a name is for queues that
 *      already exist.
 * ...
 */
FireTaskQueue.monitor = function(queueRefOrName, fn, opt_parallelCount, opt_maxBackOff,
        opt_minBackOff) { ... }

```
