### PR TITLE
Record errors encountered by failed tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple task queue for Firebase apps.",
   "main": "src/index.js",
   "scripts": {
-    "test": "node_modules/.bin/tape test/test.js",
+    "test": "node_modules/.bin/tape test/test.js | node_modules/.bin/faucet",
     "build": "node build/build.js"
   },
   "repository": {
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/isabo/FireTaskQueue#README",
   "devDependencies": {
     "closure-compiler": "git://github.com/isabo/node-closure.git#allow-newer-compiler",
+    "faucet": "0.0.1",
     "firebase-externs": "0.0.0",
     "google-closure-compiler": "^20151015.0.0",
     "tape": "^4.2.2"

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,0 +1,84 @@
+var FireTaskQueue = require('../src/');
+var util = require('./util');
+
+module.exports = {
+    queuesTaskForImmediateProcessing: queuesTaskForImmediateProcessing,
+    queuesTaskForFutureProcessing: queuesTaskForFutureProcessing,
+    processesTasks: processesTasks
+}
+
+var qRef = util.ref.child('testq');
+var q = new FireTaskQueue('TestQ', qRef);
+
+
+function queuesTaskForImmediateProcessing() {
+
+    return util.testP('Queues a task for immediate processing', function(t) {
+
+        var task = {
+            name: 'task1'
+        };
+
+        return q.schedule(task).
+            then(function(key) {
+                t.pass('Schedule method reports success');
+
+                return once(qRef.child(key), 'value').
+                    then(function(snapshot) {
+                        var actual = snapshot.val();
+                        t.equal(actual.name, task.name, 'Returns original data');
+                        t.ok(actual._dueAt < Date.now(), 'Has a due date earlier than now');
+                    });
+
+            });
+    });
+}
+
+
+function queuesTaskForFutureProcessing() {
+
+    return util.testP('Queues a task for future processing', function(t) {
+
+        var task = {
+            name: 'task2'
+        }
+
+        var when = Date.now() + 10000;
+        return q.schedule(task, when).
+            then(function(key) {
+                return once(qRef.child(key), 'value').
+                    then(function(snapshot) {
+                        var actual = snapshot.val();
+                        t.equal(actual.name, task.name, 'Returns original data');
+                        t.ok(actual._dueAt === when, 'Is scheduled 10s into the future');
+                    });
+
+            });
+
+    });
+}
+
+
+function processesTasks() {
+
+    return util.testP('Processes the queued tasks', function(t) {
+        return new Promise(function(resolve, reject) {
+            var count = 0;
+            q.monitor(function(id, task, done) {
+                console.log(task.name);
+                done();
+                count++;
+                t.equal(task.name, 'task' + count, 'Processing task ' + count);
+                if (count === 2) {
+                    q.dispose();
+                    resolve();
+                }
+            });
+        });
+    });
+}
+
+
+
+
+// Verify that a disposed queue cannot be used.

--- a/test/stores-errors.js
+++ b/test/stores-errors.js
@@ -1,0 +1,171 @@
+var util = require('./util');
+var FireTaskQueue = require('../src/');
+
+module.exports = storesErrors;
+
+
+/**
+ * Verifies that the queue stores any non-null non-undefined values returned or thrown by the
+ * consumer's callback.
+ */
+function storesErrors() {
+
+    // Prepare some data to use.
+
+    // Does not have an informative .toString() method, but it has an iterable property that has a
+    // primitive value, i.e. Firebase will manage to store it.
+    var NonCooperativeStorable = function(val) {
+        this.val = val;
+        this.foo = testData.simpleObject;
+    };
+    NonCooperativeStorable.prototype.getVal = function(){
+        return this.val;
+    };
+
+    // Has neither an informative .toString() method nor an iterable property that has a primitive
+    // value. Firebase will not be able to store this, and will treat it as null, thus losing the
+    // information.
+    var NonCooperativeEmpty = function(val) {
+        this.getVal = function() {
+            return val;
+        };
+    };
+
+    // Has its own .toString() method, which is considered more informative than iterating any
+    // internal properties.
+    var Stringable = function(val) {
+        this.val = val;
+    };
+    Stringable.prototype.toString = function() {
+        return '' + this.val;
+    };
+
+    // Has its own way of serialising itself.
+    var Jsonable = function(val) {
+        this.val = val;
+    };
+    Jsonable.prototype.toJson = function() {
+        return {val: this.val}
+    };
+
+    var testData = {
+        string: 'This is a string',
+        number: 123,
+        boolean: true,
+        date: new Date(),
+        error: new Error('Error message')
+    }
+    testData.simpleObject = {
+        string: testData.string,
+        number: testData.number,
+        boolean: testData.boolean
+    };
+    testData.nestedObject = {
+        isNested: true,
+        obj: testData.simpleObject
+    }
+    testData.jsonableObject = new Jsonable(testData.string);
+    testData.stringableObject = new Stringable(testData.number);
+    testData.nonCoopStorableObject = new NonCooperativeStorable(testData.boolean);
+    testData.nonCoopEmptyObject = new NonCooperativeEmpty(testData.boolean);
+
+    // Set up a structure that tracks what we've tested.
+    var tested = {}
+
+    // Run the test.
+    return util.testP('Records errors', function(t) {
+        return new Promise(function(resolve, reject) {
+            var qName = 'recordErrors';
+            FireTaskQueue.monitor(util.ref.child(qName), function(id, task, done) {
+
+                // The first time this is called for each task, return an error.
+                if (!task['_attempts']) {
+                    // Return a value - this signals an error.
+                    done(testData[task['type']]);
+                    return;
+                }
+
+                // This is not the first time, so compare actual with expected error value.
+                switch (task.type) {
+                    case 'string':
+                    case 'number':
+                    case 'boolean':
+                        t.equal(task._error, testData[task.type], 'Primitive value stored correctly: ' + task.type);
+                        break;
+
+                    case 'date':
+                        t.equal(typeof task._error, 'string', 'Dates are serialized as strings');
+                        t.equal(task._error, testData.date.toString(), 'Dates are serialized correctly');
+                        break;
+
+                    case 'error':
+                        t.equal(typeof task._error, 'object', 'Errors are serialized as objects');
+                        var expectedError = {
+                            name: testData.error.name,
+                            message: testData.error.message,
+                            stack: testData.error.stack
+                        }
+                        t.deepEqual(task._error, expectedError, 'Errors are serialized correctly');
+                        break;
+
+                    case 'simpleObject':
+                        t.equal(typeof task._error, 'object', 'Simple objects are not serialized');
+                        t.deepEqual(task._error, testData.simpleObject, 'Simple objects are stored correctly');
+                        break;
+
+                    case 'nestedObject':
+                        t.equal(typeof task._error, 'object', 'Nested objects are not serialized');
+                        t.deepEqual(task._error, testData.nestedObject, 'Nested objects are stored correctly');
+                        break;
+
+                    case 'jsonableObject':
+                        t.equal(typeof task._error, 'object', 'The .toJson() method is used when available');
+                        t.deepEqual(task._error, testData.jsonableObject.toJson(), 'Objects with a .toJson() method are stored correctly');
+                        break;
+
+                    case 'stringableObject':
+                        t.equal(typeof task._error, 'string', 'Non-JSONable objects are stored as strings');
+                        t.equal(task._error, testData.stringableObject.toString(), 'Objects with their own .toString() method are stored correctly');
+                        break;
+
+                    case 'nonCoopStorableObject':
+                        t.equal(typeof task._error, 'object', 'Non-cooperative storable objects are stored as objects');
+                        t.deepEqual(task._error, testData.nonCoopStorableObject, 'Non-cooperative storable objects are stored correctly');
+                        break;
+
+                    case 'nonCoopEmptyObject':
+                        t.equal(typeof task._error, 'string', 'Non-cooperative objects with no storable properties are serialized as strings');
+                        t.equal(task._error, testData.nonCoopEmptyObject.toString(), 'Non-cooperative objects with no storable properties are stored correctly');
+                        break;
+
+                    default:
+                        t.fail('We failed to handle this case: ' + task.type);
+                        done();
+                        reject();
+                }
+
+
+                // Mark this test as having been done.
+                tested[task.type] = true;
+                done();
+
+                // Have we finished the tests?
+                if (Object.keys(tested).length === Object.keys(testData).length) {
+                    resolve();
+                }
+            });
+
+            FireTaskQueue.schedule(qName, {'type': 'string'});
+            FireTaskQueue.schedule(qName, {'type': 'number'});
+            FireTaskQueue.schedule(qName, {'type': 'boolean'});
+            FireTaskQueue.schedule(qName, {'type': 'date'});
+            FireTaskQueue.schedule(qName, {'type': 'error'});
+            FireTaskQueue.schedule(qName, {'type': 'simpleObject'});
+            FireTaskQueue.schedule(qName, {'type': 'nestedObject'});
+            FireTaskQueue.schedule(qName, {'type': 'jsonableObject'});
+            FireTaskQueue.schedule(qName, {'type': 'stringableObject'});
+            FireTaskQueue.schedule(qName, {'type': 'nonCoopStorableObject'});
+            FireTaskQueue.schedule(qName, {'type': 'nonCoopEmptyObject'});
+        });
+    });
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,135 +1,19 @@
-var test = require('tape'); //require('blue-tape').test;
 var Firebase = require('firebase');
-var FireTaskQueue = require('../src/');
 
-var ref = new Firebase('https://' + process.env.FIREBASE_NAME + '.firebaseio.com/queues');
+var util = require('./util');
+var basic = require('./basic');
+var storesErrors = require('./stores-errors.js');
 
-var qRef = ref.child('testq');
-var q = new FireTaskQueue('TestQ', qRef);
-
-
-login().
-    then(queuesTaskForImmediateProcessing).
-    then(queuesTaskForFutureProcessing).
-    then(processesTasks).
+// Run the tests, then wait for Firebase to flush its buffer, then exit, which prompts the test tally.
+util.login().
+    then(basic.queuesTaskForImmediateProcessing).
+    then(basic.queuesTaskForFutureProcessing).
+    then(basic.processesTasks).
+    then(storesErrors).
     then(function() {
-        process.exit(0);
+        setTimeout(() => {
+            process.exit(0);
+        }, 3000);
     }, function(err) {
         process.exit(1);
     });
-
-
-function login() {
-    return new Promise(function(resolve, reject) {
-        try {
-            ref.authWithCustomToken(process.env.FIREBASE_TOKEN, function(err) {
-                !err ? resolve() : reject();
-            });
-        } catch (err) {
-            reject(err);
-        }
-    });
-}
-
-function once(ref, eventName) {
-    return new Promise(function(resolve, reject) {
-        ref.once(eventName, function(snapshot) {
-            resolve(snapshot);
-        }, function(err) {
-            reject(err);
-        });
-    });
-}
-
-
-/**
- * Wrapped version of tape.test() that accepts a Promise return value.
- */
-function testP(description, testFn) {
-    return new Promise(function(resolve, reject) {
-        try {
-            test(description, function(t) {
-                var p = testFn.call(null, t);
-                if (p && typeof p.then === 'function') {
-                    p = p.then(function() {
-                        t.end();
-                    }, function(err) {
-                        t.end(false);
-                    });
-                    resolve(p);
-                } else {
-                    resolve();
-                }
-            });
-        } catch (err) {
-            reject(err);
-        }
-    });
-}
-
-
-function queuesTaskForImmediateProcessing() {
-
-    return testP('Queues a task for immediate processing', function(t) {
-
-        var task = {
-            name: 'task1'
-        };
-
-        return q.schedule(task).
-            then(function(key) {
-                t.pass('Schedule method reports success');
-
-                return once(qRef.child(key), 'value').
-                    then(function(snapshot) {
-                        var actual = snapshot.val();
-                        t.equal(actual.name, task.name, 'Returns original data');
-                        t.ok(actual._dueAt < Date.now(), 'Has a due date earlier than now');
-                    });
-
-            });
-    });
-}
-
-
-function queuesTaskForFutureProcessing() {
-
-    return testP('Queues a task for future processing', function(t) {
-
-        var task = {
-            name: 'task2'
-        }
-
-        var when = Date.now() + 10000;
-        return q.schedule(task, when).
-            then(function(key) {
-                return once(qRef.child(key), 'value').
-                    then(function(snapshot) {
-                        var actual = snapshot.val();
-                        t.equal(actual.name, task.name, 'Returns original data');
-                        t.ok(actual._dueAt === when, 'Is scheduled 10s into the future');
-                    });
-
-            });
-
-    });
-}
-
-
-function processesTasks() {
-
-    return testP('Processes the queued tasks', function(t) {
-        return new Promise(function(resolve, reject) {
-            var count = 0;
-            q.monitor(function(id, task, done) {
-                console.log(task.name);
-                done();
-                count++;
-                t.equal(task.name, 'task' + count, 'Processing task ' + count);
-                if (count === 2) {
-                    resolve();
-                }
-            });
-        });
-    });
-}

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,66 @@
+var test = require('tape');
+
+var Firebase = require('firebase');
+
+var ref = new Firebase('https://' + process.env.FIREBASE_NAME + '.firebaseio.com/queues');
+
+module.exports = {
+    login: login,
+    once: once,
+    testP: testP,
+    ref: ref
+}
+
+function login() {
+    return new Promise(function(resolve, reject) {
+        try {
+            ref.authWithCustomToken(process.env.FIREBASE_TOKEN, function(err) {
+                !err ? resolve() : reject();
+            });
+        } catch (err) {
+            reject(err);
+        }
+    });
+}
+
+function once(ref, eventName) {
+    return new Promise(function(resolve, reject) {
+        ref.once(eventName, function(snapshot) {
+            resolve(snapshot);
+        }, function(err) {
+            reject(err);
+        });
+    });
+}
+
+
+/**
+ * Wrapped version of tape.test() that accepts a Promise return value.
+ */
+function testP(description, testFn) {
+    return new Promise(function(resolve, reject) {
+        try {
+            test(description, function(t) {
+                try {
+                    var p = testFn.call(null, t);
+                } catch (err) {
+                    t.end(false);
+                    reject(err);
+                    return;
+                }
+                if (p && typeof p.then === 'function') {
+                    p = p.then(function() {
+                        t.end();
+                    }, function(err) {
+                        t.end(false);
+                    });
+                    resolve(p);
+                } else {
+                    resolve();
+                }
+            });
+        } catch (err) {
+            reject(err);
+        }
+    });
+}


### PR DESCRIPTION
- When a task fails, store the error info it throws or returns in the rescheduled task.
- Fix a potential issue by making rescheduling a task an atomic operation.
