### PR TITLE
Allow ID to be specified when scheduling a task

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # FireTaskQueue
-A basic task queue for Firebase apps. I built it to make things simpler in the early stages of
-developing apps that need a queue, but which could do without the complication of introducing a
-separate queue service such as RabbitMQ at an early stage.
+A basic task queue for Node.js apps that use Firebase. I built it to make things simpler in the
+early stages of developing apps that need a queue, but which could do without the complication of
+introducing a separate queue service such as RabbitMQ at an early stage.
 
-## Rules
+## Principles
 - A task is an object that holds information that is meaningful to your app. The object's properties
   and values must be compatible with what Firebase supports, i.e., values must be primitives.
 - Tasks can be submitted for immediate execution or for execution at a specific time (i.e. delayed
   execution).
 - Tasks are not guaranteed to be processed in the order they were submitted, but that is the general
   intention.
+- If a task fails, it will be retried at exponentially increasing intervals up to 1 hour.
 - Tasks cannot have multiple user-defined statuses. They are either in the queue, i.e. not yet
   processed, or are not in the queue, i.e. processed successfully then deleted.
 - It is possible, though unlikely, that a task will be executed more than once. Make your handlers
@@ -21,7 +22,7 @@ separate queue service such as RabbitMQ at an early stage.
 
 ## Installation
 ```
-npm install --save isabo/FireTaskQueue
+npm install --save fire-task-queue
 ```
 
 ## Usage
@@ -31,13 +32,19 @@ npm install --save isabo/FireTaskQueue
 var Firebase = require('firebase');
 var FireTaskQueue = require('fire-task-queue');
 
+// Where do we put the queues?
 var queuesRef = new Firebase('https://myapp.firebaseio.com/queues');
 
 // Create a queue instance.
 var q = new FireTaskQueue('my_queue', queuesRef.child('myQueue'));
 
 // Schedule a task for immediate execution.
-q.schedule({... task data ...}).
+var taskData = {
+    a: 1,
+    b: 'two'
+};
+
+q.schedule(taskData).
     then(function(taskId) {
         // Task has been successfully scheduled.
     }, function(err) {
@@ -45,10 +52,10 @@ q.schedule({... task data ...}).
     });
 
 // Schedule a task for execution in 1 minute.
-q.schedule({... task data ...}, Date.now() + 60000).
+q.schedule(taskData, Date.now() + 60000).
     then(...);
 
-// Alternatively...
+// Alternatively, there's a static method:
 FireTaskQueue.schedule('my_queue', {...task data...}, optionalDateOrTimestamp);
 ```
 
@@ -57,13 +64,14 @@ FireTaskQueue.schedule('my_queue', {...task data...}, optionalDateOrTimestamp);
 q.monitor(function(taskId, taskData, done) {
     console.log('Processing ' + taskId);
 
-    // You can even do something asynchronous, as long as you remember to call done().
+    // You can even do something asynchronous, as long as you remember to call done(), or return
+    // a promise which when fulfilled, indicates the end of the processing for that task.
     setTimeout(function() {
         done();
     }, 500);
 });
 
-// Alternatively ...
+// Alternatively, there's a static method:
 FireTaskQueue.monitor('my_queue', function(taskId, taskData, done){...});
 ```
 
@@ -121,19 +129,181 @@ It would be a good idea to provide some rules for the queue functionality. Here'
     }
 }
 ```
+Of course, if clients are going to be enqueuing tasks, it would be advisable to tighten up the rules
+by specifying the queues that clients can write to, and the properties that are relevant for each
+queue.
+
+## API Documentation
+
+### FireTaskQueue
+Represents a task queue. The queue can be monitored for tasks, and tasks can be scheduled on the
+queue.
+
+#### new FireTaskQueue(name, ref)
+
+Creates a new queue instance.
+
+##### Arguments
+| Name | Type | Description |
+|------|------|-------------|
+| name | string | A name for the queue that can be used when invoking class methods instead of using an instance.|
+| ref  | Firebase | Firebase ref under which this queue's data should be stored.|
+
+
+
+#### q.schedule(taskData, [when, [taskId, [replace]]])
+
+Schedules a task for processing.
+
+##### Arguments
+| Name | Type | Description |
+|------|------|-------------|
+| taskData | Object | An object containing data that represents some work that needs to be done. |
+| [when]   | Date or number | Optional. A Date instance or numeric timestamp that indicates the earliest time the task should be processed. |
+| [taskId] | string | Optional. Allows you to specify your own ID for the task. Use this if you need to prevent redundant tasks from being created by logic that does not know if a task was already created elsewhere in the app. |
+| [replace]| boolean | Optional. If you specify a value for *taskId*, this determines whether to replace an existing task with the specified ID, or to fail with an error of `FireTaskQueue.DuplicateIdError`. Default: *false*, i.e., do not replace an existing task.|
+
+##### Returns
+Promise.
+Resolves to the ID of the newly created task, or is rejected with an error.
+If rejected because `taskId` specified the ID of an existing task, and `replace` was `false` or
+undefined, the error will be of type `FireTaskQueue.DuplicateIdError`.
+
+
+
+#### q.monitor(callback, [parallelCount, [maxBackOff, [minBackOff]]])
+
+Registers a callback function that will be called for each task in the queue at the appropriate time.
+Currently, multiple monitors are not supported so dan't call this more than once per queue instance.
+
+##### Arguments
+| Name | Type | Description |
+|------|------|-------------|
+| callback | function(taskId, taskData, done) | A function that knows how to process a task that was scheduled. The function should accept the following arguments: *taskId* (a string), *taskData* (an Object), and *done* (a function). See below for usage of *done()*. |
+| [parallelCount] | number | Optional. The number of tasks that are allowed execute in parallel. |
+| [maxBackOff] | number | Optional. The maximum interval, in microseconds, between retry attempts of failed tasks.|
+| [minBackOff] | number | Optional. The minimum interval, in microseconds, between retry attempts of failed tasks.|
+
+##### Indicate that Processing is Complete
+FireTaskQueue assumes that your callback performs asynchronously. Therefore, you must indicate when
+processing is complete, using any of the following:
+- **Call *done()*.** If called with no arguments, the task is considered to have been processed
+  successfully and will be deleted. If called with anything except null or undefined, the task is
+  considered to have failed, and will be retried. The value that you provide to *done()* will be
+  stored in the task for debugging purposes.
+- **Return a promise.** Processing is considered complete when the promise is fulfilled. If the promise
+  is resolved, the task is considered to have been processed successfully and will be deleted. If
+  the promise is rejected, the task is considered to have failed and will be retried. The value with
+  which the promise is rejected will be stored in the task for debugging purposes.
+- **Throw an exception, or allow one to be thrown**, so that the callback fails immediately. The task
+  will be considered to have failed and will be retried. The details of the exception will be
+  stored in the task for debugging purposes.
+
+
+
+#### q.dispose()
+
+Stops monitoring the queue and releases the memory used by the queue.
+The unprocessed tasks remain in Firebase.
+
+
+
+#### FireTaskQueue.DuplicateIdError
+
+This error is the rejected value when `schedule()` fails because there is already a task with the
+specified ID.
+
+
+
+#### FireTaskQueue.schedule(queueName, taskData, [when, [taskId, [replace]]])
+
+Schedules a task for processing.
+The static form of `q.schedule()`.
+
+##### Arguments
+| Name | Type | Description |
+|------|------|-------------|
+| queueName | string | The name of the queue. If no such queue instance has been created, the call will return a rejected promise.|
+| taskData | Object | An object containing data that represents some work that needs to be done. |
+| [when]   | Date or number | Optional. A Date instance or numeric timestamp that indicates the earliest time the task should be processed. |
+| [taskId] | string | Optional. Allows you to specify your own ID for the task. Use this if you need to prevent redundant tasks from being created by logic that does not know if a task was already created elsewhere in the app. |
+| [replace]| boolean | Optional. If you specify a value for *taskId*, this determines whether to replace an existing task with the specified ID, or to fail with an error of `FireTaskQueue.DuplicateIdError`. Default: *false*, i.e., do not replace an existing task.|
+
+##### Returns
+Promise.
+Resolves to the ID of the newly created task, or is rejected with an error.
+If rejected because `taskId` specified the ID of an existing task, and `replace` was `false` or
+undefined, the error will be of type `FireTaskQueue.DuplicateIdError`.
+
+
+
+#### FireTaskQueue.get(queueName)
+
+Returns the instance of the named queue, if it exists. Otherwise: undefined.
+
+##### Arguments
+| Name | Type | Description |
+|------|------|-------------|
+| queueName | string | The name of the queue. |
+
+
+
+#### FireTaskQueue.monitor(queueRefOrName, callback, [parallelCount, [maxBackOff, [minBackOff]]])
+
+Registers a callback function that will be called for each task in the queue at the appropriate time.
+Currently, multiple monitors are not supported so dan't call this more than once per queue instance.
+This is the static form of `q.monitor()`.
+
+##### Arguments
+| Name | Type | Description |
+|------|------|-------------|
+| queueRefOrName | string or Firebase | The name of an existing queue, or the Firebase reference of a queue. If a Firebase reference is supplied, the queue will be created if it does not yet exist. |
+| callback | function(taskId, taskData, done) | A function that knows how to process a task that was scheduled. The function should accept the following arguments: *taskId* (a string), *taskData* (an Object), and *done* (a function). See below for usage of *done()*.
+| [parallelCount] | number | Optional. The number of tasks that are allowed execute in parallel. |
+| [maxBackOff] | number | Optional. The maximum interval, in microseconds, between retry attempts of failed tasks.|
+| [minBackOff] | number | Optional. The minimum interval, in microseconds, between retry attempts of failed tasks.|
+
+##### Indicate that Processing is Complete
+FireTaskQueue assumes that your callback performs asynchronously. Therefore, you must indicate when
+processing is complete, using any of the following:
+- **Call *done()*.** If called with no arguments, the task is considered to have been processed
+  successfully and will be deleted. If called with anything except null or undefined, the task is
+  considered to have failed, and will be retried. The value that you provide to *done()* will be
+  stored in the task for debugging purposes.
+- **Return a promise.** Processing is considered complete when the promise is fulfilled. If the promise
+  is resolved, the task is considered to have been processed successfully and will be deleted. If
+  the promise is rejected, the task is considered to have failed and will be retried. The value with
+  which the promise is rejected will be stored in the task for debugging purposes.
+- **Throw an exception, or allow one to be thrown**, so that the callback fails immediately. The task
+  will be considered to have failed and will be retried. The details of the exception will be
+  stored in the task for debugging purposes.
+
+
+
+#### FireTaskQueue.disposeAll()
+
+Stops monitoring all queues and releases the memory used by the queues.
+The unprocessed tasks remain in Firebase.
+Call this when shutting down.
+
+
 
 ## Developers
+This section is relevant if you want to fix a bug or develop a new feature.
 
-#### Build
+### Build
 It's not really building in this case, just performing a static analysis of the source code.
+This requires a JVM to have been installed on your machine.
 ```
 npm run build
 ```
 
 ### Test
-Ensure that `FTQ_FIREBASE_NAME` and `FTQ_FIREBASE_TOKEN` environment variables have been set to
-appropriate values for accessing your Firebase instance.
-Then run:
+- You need to have a Firebase instance that can be written to for testing. The test data will be
+  written under `/queues/`.
+- Ensure that `FTQ_FIREBASE_NAME` and `FTQ_FIREBASE_TOKEN` environment variables have been set to
+  appropriate values for accessing your Firebase instance.
+
 ```
 npm test
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -736,14 +736,22 @@ FireTaskQueue.DuplicateIdError.prototype.constructor = FireTaskQueue.DuplicateId
  *
  * @param {string} queueName The name of the queue.
  * @param {!Object} taskData A task that needs to be processed.
- * @param {Date|number=} when When to try to process the item.
- * @return {!Promise} which resolves if successful or is rejected if not.
+ * @param {Date|number=} opt_when When to try to process the item.
+ * @param {string=} opt_taskId The ID to assign the new task. This is not necessary, but can be
+ *      used to prevent duplicate tasks being created.
+ * @param {boolean=} opt_replace If an ID was specified, whether this task replaces an existing one
+ *      with the same ID. Default: false. If true, an existing task may be overwritten with the new
+ *      task, an no error will be returned.
+ * @return {!Promise<string,(Error|FireTaskQueue.DuplicateIdError)>} which resolves to the ID of the
+ *      newly created task if successful or is rejected if not. If rejected because opt_taskId was
+ *      specified and a task with the same ID already exists, the rejected value will be an error of
+ *      the type FireTaskQueue.DuplicateIdError.
  */
-FireTaskQueue.schedule = function(queueName, taskData, when) {
+FireTaskQueue.schedule = function(queueName, taskData, opt_when, opt_taskId, opt_replace) {
 
     var q = FireTaskQueue.get(queueName);
     if (q) {
-        return q.schedule(taskData, when);
+        return q.schedule(taskData, opt_when, opt_taskId, opt_replace);
     } else {
         return Promise.reject(new Error('No such queue'));
     }

--- a/test/accepts-promises.js
+++ b/test/accepts-promises.js
@@ -1,15 +1,24 @@
 var util = require('./util');
 var FireTaskQueue = require('../src/');
 
-module.exports = {
-    acceptsPromises: acceptsPromises,
-    handlesRejectedPromises: handlesRejectedPromises
-}
+
+module.exports = function() {
+
+    return Promise.resolve().
+        then(acceptsPromises).
+        then(handlesRejectedPromises);
+};
+
 
 
 function acceptsPromises() {
 
-    var q = new FireTaskQueue('processorCanReturnPromiseQ', util.ref.child('processorCanReturnPromiseQ'));
+    // Generate a random key to use for the queue, so that we're not using leftovers of previous failed
+    // tests.
+    var queueKey = 'test-return-promises-' + util.ref.push().key();
+    var qRef = util.ref.child(queueKey);
+
+    var q = new FireTaskQueue('ReturnPromises', qRef);
     q.schedule({});
 
     return util.testP('Accepts promise as return value', function(t) {
@@ -73,7 +82,12 @@ function acceptsPromises() {
 
 function handlesRejectedPromises() {
 
-    var q = new FireTaskQueue('rejectedPromises', util.ref.child('rejectedPromises'));
+    // Generate a random key to use for the queue, so that we're not using leftovers of previous failed
+    // tests.
+    var queueKey = 'test-rejected-promises-' + util.ref.push().key();
+    var qRef = util.ref.child(queueKey);
+
+    var q = new FireTaskQueue('RejectedPromises', qRef);
     q.schedule({});
 
     return util.testP('Treats a rejected promise as a task failure', function(t) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,14 +1,23 @@
 var FireTaskQueue = require('../src/');
 var util = require('./util');
 
-module.exports = {
-    queuesTaskForImmediateProcessing: queuesTaskForImmediateProcessing,
-    queuesTaskForFutureProcessing: queuesTaskForFutureProcessing,
-    processesTasks: processesTasks
-}
 
-var qRef = util.ref.child('testq');
-var q = new FireTaskQueue('TestQ', qRef);
+module.exports = function() {
+
+    return Promise.resolve().
+        then(queuesTaskForImmediateProcessing).
+        then(queuesTaskWithID).
+        then(failsToQueueTaskWithDuplicateID).
+        then(queuesTaskForFutureProcessing).
+        then(processesTasks);
+};
+
+
+// Generate a random key to use for the queue, so that we're not using leftovers of previous failed
+// tests.
+var queueKey = 'test-basic-' + util.ref.push().key();
+var qRef = util.ref.child(queueKey);
+var q = new FireTaskQueue('BasicTestQueue', qRef);
 
 
 function queuesTaskForImmediateProcessing() {
@@ -23,13 +32,70 @@ function queuesTaskForImmediateProcessing() {
             then(function(key) {
                 t.pass('Schedule method reports success');
 
-                return once(qRef.child(key), 'value').
+                return util.once(qRef.child(key), 'value').
                     then(function(snapshot) {
                         var actual = snapshot.val();
                         t.equal(actual.name, task.name, 'Returns original data');
                         t.ok(actual._dueAt < Date.now(), 'Has a due date earlier than now');
                     });
+            });
+    });
+}
 
+
+function queuesTaskWithID() {
+
+    return util.testP('Queues a task with a specified ID', function(t) {
+
+        var id = 'xyz123';
+
+        var task = {
+            name: 'task2'
+        }
+
+        return q.schedule(task, undefined, id).
+            then(function(key) {
+
+                t.equal(key, id, 'schedule() returns the specified ID');
+
+                return util.once(qRef.child(id), 'value').
+                    then(function(snapshot) {
+                        var actual = snapshot.val();
+                        t.equal(actual.name, task.name, 'Task was created using the specified ID');
+                    });
+            });
+    });
+}
+
+
+function failsToQueueTaskWithDuplicateID() {
+
+    return util.testP('Fails to queue a task with a duplicate ID', function(t) {
+
+        var id = 'xyz123';
+
+        var task = {
+            name: 'task2 duplicate'
+        }
+
+        return q.schedule(task, undefined, id).
+            then(function(key) {
+
+                t.fail('schedule() reports that the task was queued, but it should have been rejected');
+
+            }, function(err) {
+
+                t.pass('schedule() reports that the task was not queued');
+                t.ok(err instanceof FireTaskQueue.DuplicateIdError, 'A DuplicateIdError was returned');
+            }).
+            then(function() {
+
+                // Verify that the existing task was not updated or overwritten.
+                return util.once(qRef.child(id), 'value').
+                    then(function(snapshot) {
+                        var actual = snapshot.val();
+                        t.equal(actual.name, 'task2', 'The existing task was not overwritten');
+                    });
             });
     });
 }
@@ -40,21 +106,19 @@ function queuesTaskForFutureProcessing() {
     return util.testP('Queues a task for future processing', function(t) {
 
         var task = {
-            name: 'task2'
+            name: 'task3'
         }
 
-        var when = Date.now() + 10000;
+        var when = Date.now() + 5000;
         return q.schedule(task, when).
             then(function(key) {
-                return once(qRef.child(key), 'value').
+                return util.once(qRef.child(key), 'value').
                     then(function(snapshot) {
                         var actual = snapshot.val();
                         t.equal(actual.name, task.name, 'Returns original data');
-                        t.ok(actual._dueAt === when, 'Is scheduled 10s into the future');
+                        t.ok(actual._dueAt === when, 'Is scheduled 5s into the future');
                     });
-
             });
-
     });
 }
 
@@ -65,15 +129,23 @@ function processesTasks() {
         return new Promise(function(resolve, reject) {
             var count = 0;
             q.monitor(function(id, task, done) {
-                console.log(task.name);
-                done();
                 count++;
                 t.equal(task.name, 'task' + count, 'Processing task ' + count);
-                if (count === 2) {
-                    q.dispose();
+                done();
+                if (count === 3) {
                     resolve();
                 }
             });
+        }).
+        then(function() {
+            // Verify that the queue is empty.
+            return util.once(qRef, 'value').
+                then(function(snapshot) {
+                    t.ok(!snapshot.exists(), 'Queue is now empty');
+                });
+        }).
+        then(function() {
+            q.dispose();
         });
     });
 }

--- a/test/rescheduling.js
+++ b/test/rescheduling.js
@@ -1,0 +1,83 @@
+var FireTaskQueue = require('../src/');
+var util = require('./util');
+
+
+module.exports = failedTaskIsReprocessed;
+
+
+// Generate a random key to use for the queue, so that we're not using leftovers of previous failed
+// tests.
+var queueKey = 'test-rescheduling-' + util.ref.push().key();
+var qRef = util.ref.child(queueKey);
+
+
+function failedTaskIsReprocessed() {
+
+    return util.testP('Failed tasks are rescheduled', function(t) {
+
+        var q = new FireTaskQueue('ReschedulingQueue', qRef);
+
+        var task = {
+            name: 'task1'
+        }
+
+        return q.schedule(task).
+            then(function(key) {
+                t.pass('Task was successfully scheduled');
+            }, function(err) {
+                t.error(err, 'Failed to schedule task');
+                throw err;
+            }).
+            then(function() {
+
+                return new Promise(function(resolve, reject) {
+
+                    q.monitor(function(id, task, done) {
+
+                        // Try different ways of failing.
+                        var attempts = 1 + (task._attempts || 0);
+
+                        if (attempts < 5) {
+                            t.pass('Task was presented for processing ' + attempts + ' times');
+                        }
+
+                        switch (attempts) {
+                            case 1:
+                                throw new Error('Attempt 1 failed on purpose');
+
+                            case 2:
+                                t.pass('Throwing an exception fails the task');
+                                t.equal(task._error.message, 'Attempt 1 failed on purpose', 'The exception was serialized correctly');
+                                done('Attempt 2 failed on purpose');
+                                break;
+
+                            case 3:
+                                t.pass('Calling done() with a string fails the task');
+                                t.equal(task._error, 'Attempt 2 failed on purpose', 'The done() argument was stored correctly');
+                                return Promise.reject('Attempt 3 failed on purpose');
+
+                            case 4:
+                                t.pass('Returning a rejected promise fails the task');
+                                t.equal(task._error, 'Attempt 3 failed on purpose', 'The promise\'s reject() value was stored correctly');
+                                done();
+
+                                // Finish the test after a delay which gives us a chance to see if the task will be processed any extra times.
+                                setTimeout(function(){
+                                    resolve();
+                                }, 10000);
+                                break;
+
+                            default:
+                                t.fail('The task was presented for processing an extra time!');
+                                reject();
+                        }
+
+                    });
+                });
+            }).
+            then(function() {
+                q.dispose();
+            });
+
+    });
+}

--- a/test/stores-errors.js
+++ b/test/stores-errors.js
@@ -75,7 +75,7 @@ function storesErrors() {
     // Run the test.
     return util.testP('Records errors', function(t) {
         return new Promise(function(resolve, reject) {
-            var qName = 'recordErrors';
+            var qName = 'test-record-errors-' + util.ref.push().key();
             FireTaskQueue.monitor(util.ref.child(qName), function(id, task, done) {
 
                 // The first time this is called for each task, return an error.

--- a/test/test.js
+++ b/test/test.js
@@ -18,7 +18,7 @@ util.login().
         setTimeout(() => {
             FireTaskQueue.disposeAll();
             process.exit(0);
-        }, 3000);
+        }, 5000);
     }, function(err) {
         FireTaskQueue.disposeAll();
         process.exit(1);

--- a/test/test.js
+++ b/test/test.js
@@ -1,22 +1,25 @@
 var Firebase = require('firebase');
 
+var FireTaskQueue = require('../src/');
 var util = require('./util');
-var basic = require('./basic');
+
+var runBasicTests = require('./basic');
+var reschedulesTasks = require('./rescheduling');
 var storesErrors = require('./stores-errors.js');
 var acceptsPromises = require('./accepts-promises.js');
 
 // Run the tests, then wait for Firebase to flush its buffer, then exit, which prompts the test tally.
 util.login().
-    then(basic.queuesTaskForImmediateProcessing).
-    then(basic.queuesTaskForFutureProcessing).
-    then(basic.processesTasks).
-    then(acceptsPromises.acceptsPromises).
-    then(acceptsPromises.handlesRejectedPromises).
+    then(runBasicTests).
+    then(reschedulesTasks).
+    then(acceptsPromises).
     then(storesErrors).
     then(function() {
         setTimeout(() => {
+            FireTaskQueue.disposeAll();
             process.exit(0);
         }, 3000);
     }, function(err) {
+        FireTaskQueue.disposeAll();
         process.exit(1);
     });


### PR DESCRIPTION
Allows you to specify your own ID for the task. Use this if you need to prevent redundant tasks from being created by logic that does not know if a task was already created elsewhere in the app.
#3 #4 #14 #18
